### PR TITLE
Remove `sealed class`

### DIFF
--- a/src/W4k.AspNetCore.Correlator/Context/CorrelationContextContainer.CorrelationScope.cs
+++ b/src/W4k.AspNetCore.Correlator/Context/CorrelationContextContainer.CorrelationScope.cs
@@ -1,9 +1,6 @@
 ﻿namespace W4k.AspNetCore.Correlator.Context
 {
-    /// <summary>
-    /// Default implementation of correlation context container.
-    /// </summary>
-    internal sealed partial class CorrelationContextContainer
+    internal partial class CorrelationContextContainer
     {
         internal class CorrelationScope : ICorrelationScope
         {

--- a/src/W4k.AspNetCore.Correlator/Context/CorrelationContextContainer.cs
+++ b/src/W4k.AspNetCore.Correlator/Context/CorrelationContextContainer.cs
@@ -5,10 +5,7 @@ using W4k.AspNetCore.Correlator.Context.Types;
 
 namespace W4k.AspNetCore.Correlator.Context
 {
-    /// <summary>
-    /// Default implementation of correlation context container.
-    /// </summary>
-    internal sealed partial class CorrelationContextContainer
+    internal partial class CorrelationContextContainer
         : ICorrelationScopeFactory, ICorrelationContextAccessor, IDisposable
     {
         private static readonly AsyncLocal<CorrelationContext?> LocalContext = new AsyncLocal<CorrelationContext?>();


### PR DESCRIPTION
Remove `sealed` from

1. `internal` types - we are masters of our domain
2. types which are anyway reference by interface type - `sealed` has no impact here