### PR TITLE
Revert use of `Microsoft.Extensions.DependencyInjection` namespace

### DIFF
--- a/src/W4k.AspNetCore.Correlator/Extensions/DependencyInjection/CorrelatorBuilderExtensions.cs
+++ b/src/W4k.AspNetCore.Correlator/Extensions/DependencyInjection/CorrelatorBuilderExtensions.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Linq;
-using W4k.AspNetCore.Correlator;
+using Microsoft.Extensions.DependencyInjection;
 using W4k.AspNetCore.Correlator.Context;
 using W4k.AspNetCore.Correlator.Extensions.DependencyInjection;
 using W4k.AspNetCore.Correlator.Http;
 using W4k.AspNetCore.Correlator.Validation;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace W4k.AspNetCore.Correlator
 {
     /// <summary>
     /// Extensions of <see cref="ICorrelatorBuilder"/>.
     /// </summary>
-    public static class W4kCorrelatorBuilderExtensions
+    public static class CorrelatorBuilderExtensions
     {
         /// <summary>
         /// Registers correlation context factory.
@@ -140,10 +140,10 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when trying to register correlation context factory second time.</exception>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder WithCorrelationContextFactory<T>(this ICorrelatorBuilder builder)
             where T : class, ICorrelationContextFactory =>
-            Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithCorrelationContextFactory<T>(builder);
+            W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithCorrelationContextFactory<T>(builder);
 
         /// <summary>
         /// Registers default implementation of correlation context factory.
@@ -152,9 +152,9 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// Same instance of Correlator builder.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder WithDefaultCorrelationContextFactory(this ICorrelatorBuilder builder) =>
-            Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithDefaultCorrelationContextFactory(builder);
+            W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithDefaultCorrelationContextFactory(builder);
 
         /// <summary>
         /// Registers correlation emitter.
@@ -169,10 +169,10 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when trying to register correlation emitter second time.</exception>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder WithCorrelationEmitter<T>(this ICorrelatorBuilder builder)
             where T : class, ICorrelationEmitter =>
-            Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithCorrelationEmitter<T>(builder);
+            W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithCorrelationEmitter<T>(builder);
 
         /// <summary>
         /// Registers correlation emitter.
@@ -181,9 +181,9 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// Same instance of Correlator builder.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder WithDefaultCorrelationEmitter(this ICorrelatorBuilder builder) =>
-            Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithDefaultCorrelationEmitter(builder);
+            W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithDefaultCorrelationEmitter(builder);
 
         /// <summary>
         /// Registers correlation validator.
@@ -196,9 +196,9 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="validator"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when trying to register correlation validator second time.</exception>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder WithValidator<T>(this ICorrelatorBuilder builder, T validator)
             where T : ICorrelationValidator =>
-            Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithValidator(builder, validator);
+            W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithValidator(builder, validator);
     }
 }

--- a/src/W4k.AspNetCore.Correlator/Extensions/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/W4k.AspNetCore.Correlator/Extensions/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -5,12 +5,12 @@ using W4k.AspNetCore.Correlator.Context;
 using W4k.AspNetCore.Correlator.Http;
 using W4k.AspNetCore.Correlator.Options;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace W4k.AspNetCore.Correlator
 {
     /// <summary>
     /// Extensions of <see cref="IHttpClientBuilder"/>.
     /// </summary>
-    public static class W4kHttpClientBuilderExtensions
+    public static class HttpClientBuilderExtensions
     {
         /// <summary>
         /// Configures HTTP client with <see cref="CorrelatorHttpMessageHandler"/>.
@@ -55,9 +55,9 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// HTTP client builder configured to use correlator message handler.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static IHttpClientBuilder WithCorrelation(this IHttpClientBuilder builder) =>
-            W4kHttpClientBuilderExtensions.WithCorrelation(builder);
+            Correlator.HttpClientBuilderExtensions.WithCorrelation(builder);
 
         /// <summary>
         /// Configures HTTP client with configured <see cref="CorrelatorHttpMessageHandler"/>.
@@ -67,10 +67,10 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// HTTP client builder configured to use correlator message handler.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static IHttpClientBuilder WithCorrelation(
             this IHttpClientBuilder builder,
             PropagationSettings propagationSettings) =>
-            W4kHttpClientBuilderExtensions.WithCorrelation(builder, propagationSettings);
+            Correlator.HttpClientBuilderExtensions.WithCorrelation(builder, propagationSettings);
     }
 }

--- a/src/W4k.AspNetCore.Correlator/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/W4k.AspNetCore.Correlator/Extensions/DependencyInjection/ServiceCollectionExtensions.cs
@@ -5,12 +5,12 @@ using W4k.AspNetCore.Correlator.Extensions.DependencyInjection;
 using W4k.AspNetCore.Correlator.Http;
 using W4k.AspNetCore.Correlator.Options;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace W4k.AspNetCore.Correlator
 {
     /// <summary>
     /// Extensions of <see cref="IServiceCollection"/>.
     /// </summary>
-    public static class W4kCorrelatorServiceCollectionExtensions
+    public static class ServiceCollectionExtensions
     {
         /// <summary>
         /// Adds default components required by Correlator to services collection.
@@ -96,9 +96,9 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// Correlator builder.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder AddDefaultCorrelator(this IServiceCollection services) =>
-            W4kCorrelatorServiceCollectionExtensions.AddDefaultCorrelator(services);
+            W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddDefaultCorrelator(services);
 
         /// <summary>
         /// Adds default components required by Correlator to services collection.
@@ -108,11 +108,11 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// Correlator builder.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder AddDefaultCorrelator(
             this IServiceCollection services,
             Action<CorrelatorOptions> configureOptions) =>
-            W4kCorrelatorServiceCollectionExtensions.AddDefaultCorrelator(services, configureOptions);
+            W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddDefaultCorrelator(services, configureOptions);
 
         /// <summary>
         /// Adds components required by Correlator to services collection.
@@ -121,9 +121,9 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// <returns>
         /// Correlator builder.
         /// </returns>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder AddCorrelator(this IServiceCollection services) =>
-            W4kCorrelatorServiceCollectionExtensions.AddCorrelator(services);
+            W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddCorrelator(services);
 
         /// <summary>
         /// Adds components required by Correlator to services collection.
@@ -134,8 +134,8 @@ namespace W4k.AspNetCore.Correlator.Extensions.DependencyInjection
         /// Correlator builder.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="configureOptions"/> is <c>null</c>.</exception>
-        [Obsolete("Use extensions from `Microsoft.Extensions.DependencyInjection`.")]
+        [Obsolete("Use extensions from `W4k.AspNetCore.Correlator`.")]
         public static ICorrelatorBuilder AddCorrelator(this IServiceCollection services, Action<CorrelatorOptions> configureOptions) =>
-            W4kCorrelatorServiceCollectionExtensions.AddCorrelator(services, configureOptions);
+            W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddCorrelator(services, configureOptions);
     }
 }

--- a/src/W4k.AspNetCore.Correlator/PublicAPI.Shipped.txt
+++ b/src/W4k.AspNetCore.Correlator/PublicAPI.Shipped.txt
@@ -1,7 +1,4 @@
 #nullable enable
-Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions
-Microsoft.Extensions.DependencyInjection.W4kCorrelatorServiceCollectionExtensions
-Microsoft.Extensions.DependencyInjection.W4kHttpClientBuilderExtensions
 W4k.AspNetCore.Correlator.ApplicationBuilderExtensions
 W4k.AspNetCore.Correlator.Context.CorrelationContext
 W4k.AspNetCore.Correlator.Context.CorrelationContext.CorrelationContext(W4k.AspNetCore.Correlator.CorrelationId! correlationId) -> void
@@ -24,6 +21,7 @@ W4k.AspNetCore.Correlator.CorrelationId
 W4k.AspNetCore.Correlator.CorrelationId.Equals(W4k.AspNetCore.Correlator.CorrelationId? other) -> bool
 W4k.AspNetCore.Correlator.CorrelationId.IsEmpty.get -> bool
 W4k.AspNetCore.Correlator.CorrelationId.Value.get -> string!
+W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions
 W4k.AspNetCore.Correlator.Extensions.ApplicationBuilderExtensions
 W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder
 W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
@@ -32,6 +30,7 @@ W4k.AspNetCore.Correlator.Http.CorrelatorHttpMessageHandler.CorrelatorHttpMessag
 W4k.AspNetCore.Correlator.Http.HttpHeaders
 W4k.AspNetCore.Correlator.Http.ICorrelationEmitter
 W4k.AspNetCore.Correlator.Http.ICorrelationEmitter.Emit(Microsoft.AspNetCore.Http.HttpContext! httpContext, W4k.AspNetCore.Correlator.Context.CorrelationContext! correlationContext) -> System.Threading.Tasks.Task!
+W4k.AspNetCore.Correlator.HttpClientBuilderExtensions
 W4k.AspNetCore.Correlator.Options.CorrelatorOptions
 W4k.AspNetCore.Correlator.Options.CorrelatorOptions.CorrelatorOptions() -> void
 W4k.AspNetCore.Correlator.Options.CorrelatorOptions.Emit.get -> W4k.AspNetCore.Correlator.Options.PropagationSettings
@@ -59,6 +58,7 @@ W4k.AspNetCore.Correlator.Options.PropagationSettings.Equals(W4k.AspNetCore.Corr
 W4k.AspNetCore.Correlator.Options.PropagationSettings.HeaderName.get -> string!
 W4k.AspNetCore.Correlator.Options.PropagationSettings.PropagationSettings() -> void
 W4k.AspNetCore.Correlator.Options.PropagationSettings.Settings.get -> W4k.AspNetCore.Correlator.Options.HeaderPropagation
+W4k.AspNetCore.Correlator.ServiceCollectionExtensions
 W4k.AspNetCore.Correlator.Validation.CorrelationValueLengthValidator
 W4k.AspNetCore.Correlator.Validation.CorrelationValueLengthValidator.CorrelationValueLengthValidator(ushort length) -> void
 W4k.AspNetCore.Correlator.Validation.CorrelationValueLengthValidator.Validate(string? value) -> W4k.AspNetCore.Correlator.Validation.ValidationResult
@@ -78,23 +78,19 @@ override W4k.AspNetCore.Correlator.Options.PropagationSettings.Equals(object? ob
 override W4k.AspNetCore.Correlator.Options.PropagationSettings.GetHashCode() -> int
 override W4k.AspNetCore.Correlator.Validation.ValidationResult.Equals(object? obj) -> bool
 override W4k.AspNetCore.Correlator.Validation.ValidationResult.GetHashCode() -> int
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithCorrelationContextFactory<T>(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithCorrelationEmitter<T>(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithDefaultCorrelationContextFactory(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithDefaultCorrelationEmitter(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorBuilderExtensions.WithValidator<T>(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder, T validator) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorServiceCollectionExtensions.AddCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorServiceCollectionExtensions.AddCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<W4k.AspNetCore.Correlator.Options.CorrelatorOptions!>! configureOptions) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorServiceCollectionExtensions.AddDefaultCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kCorrelatorServiceCollectionExtensions.AddDefaultCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<W4k.AspNetCore.Correlator.Options.CorrelatorOptions!>! configureOptions) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kHttpClientBuilderExtensions.WithCorrelation(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
-static Microsoft.Extensions.DependencyInjection.W4kHttpClientBuilderExtensions.WithCorrelation(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, W4k.AspNetCore.Correlator.Options.PropagationSettings propagationSettings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static W4k.AspNetCore.Correlator.ApplicationBuilderExtensions.UseCorrelator(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static W4k.AspNetCore.Correlator.CorrelationId.FromString(string? value) -> W4k.AspNetCore.Correlator.CorrelationId!
 static W4k.AspNetCore.Correlator.CorrelationId.implicit operator string!(W4k.AspNetCore.Correlator.CorrelationId! correlationId) -> string!
 static W4k.AspNetCore.Correlator.CorrelationId.operator !=(W4k.AspNetCore.Correlator.CorrelationId? left, W4k.AspNetCore.Correlator.CorrelationId? right) -> bool
 static W4k.AspNetCore.Correlator.CorrelationId.operator ==(W4k.AspNetCore.Correlator.CorrelationId? left, W4k.AspNetCore.Correlator.CorrelationId? right) -> bool
+static W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithCorrelationContextFactory<T>(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithCorrelationEmitter<T>(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithDefaultCorrelationContextFactory(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithDefaultCorrelationEmitter(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.CorrelatorBuilderExtensions.WithValidator<T>(this W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder! builder, T validator) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
 static W4k.AspNetCore.Correlator.Extensions.ApplicationBuilderExtensions.UseCorrelator(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+static W4k.AspNetCore.Correlator.HttpClientBuilderExtensions.WithCorrelation(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static W4k.AspNetCore.Correlator.HttpClientBuilderExtensions.WithCorrelation(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, W4k.AspNetCore.Correlator.Options.PropagationSettings propagationSettings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static W4k.AspNetCore.Correlator.Options.LoggingScopeSettings.IncludeLoggingScope(string! correlationKey = "Correlation") -> W4k.AspNetCore.Correlator.Options.LoggingScopeSettings
 static W4k.AspNetCore.Correlator.Options.LoggingScopeSettings.operator !=(W4k.AspNetCore.Correlator.Options.LoggingScopeSettings left, W4k.AspNetCore.Correlator.Options.LoggingScopeSettings right) -> bool
 static W4k.AspNetCore.Correlator.Options.LoggingScopeSettings.operator ==(W4k.AspNetCore.Correlator.Options.LoggingScopeSettings left, W4k.AspNetCore.Correlator.Options.LoggingScopeSettings right) -> bool
@@ -102,6 +98,10 @@ static W4k.AspNetCore.Correlator.Options.PropagationSettings.KeepIncomingHeaderN
 static W4k.AspNetCore.Correlator.Options.PropagationSettings.PropagateAs(string! headerName) -> W4k.AspNetCore.Correlator.Options.PropagationSettings
 static W4k.AspNetCore.Correlator.Options.PropagationSettings.operator !=(W4k.AspNetCore.Correlator.Options.PropagationSettings left, W4k.AspNetCore.Correlator.Options.PropagationSettings right) -> bool
 static W4k.AspNetCore.Correlator.Options.PropagationSettings.operator ==(W4k.AspNetCore.Correlator.Options.PropagationSettings left, W4k.AspNetCore.Correlator.Options.PropagationSettings right) -> bool
+static W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<W4k.AspNetCore.Correlator.Options.CorrelatorOptions!>! configureOptions) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddDefaultCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
+static W4k.AspNetCore.Correlator.ServiceCollectionExtensions.AddDefaultCorrelator(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<W4k.AspNetCore.Correlator.Options.CorrelatorOptions!>! configureOptions) -> W4k.AspNetCore.Correlator.Extensions.DependencyInjection.ICorrelatorBuilder!
 static W4k.AspNetCore.Correlator.Validation.ValidationResult.Invalid(string! reason) -> W4k.AspNetCore.Correlator.Validation.ValidationResult
 static W4k.AspNetCore.Correlator.Validation.ValidationResult.operator !=(W4k.AspNetCore.Correlator.Validation.ValidationResult left, W4k.AspNetCore.Correlator.Validation.ValidationResult right) -> bool
 static W4k.AspNetCore.Correlator.Validation.ValidationResult.operator ==(W4k.AspNetCore.Correlator.Validation.ValidationResult left, W4k.AspNetCore.Correlator.Validation.ValidationResult right) -> bool


### PR DESCRIPTION
As per [Options pattern guidance for .NET library authors / Namespace guidance](https://learn.microsoft.com/en-us/dotnet/core/extensions/options-library-authors#namespace-guidance):

> DO NOT use the `Microsoft.Extensions.DependencyInjection` namespace for non-official Microsoft packages.

... reverting previous change when this namespace was set for DI and other extension methods (in expectation to ease use of the library). This indeed is not official Microsoft package 😅 